### PR TITLE
Update README, avoid non-audio files during conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,34 @@
 # Voicebank-Converter
-A python converter to convert UTAU voicebanks to hiragana from romaji (and vice versa)
-# How to use
-The Converter only requires 2 positional arguments, the folder location, and the conversion mode
+A pure Python converter to convert UTAU voicebank samples from hiragana to romaji (and vice versa).
+
+# Usage
 ```cl
-python main.py <folder_path> <conversion_mode>
+python main.py path [path ...] {hiragana, romaji}
 ```
 
-There are 2 conversion modes, "hiragana" and "romaji". "hiragana" will convert the wav files in a voicebank to hiragana format ("_a-a-i-a-u-e-a" -> "_ああいあうえあ") and "romaji" will do the inverse ("_ああいあうえあ" -> "_a-a-i-a-u-e-a")
+There are 2 conversion modes: "hiragana" or "romaji".  
+"hiragana" will convert the wav files in the path to hiragana. (i.e. "_a-a-i-a-u-e-a" -> "_ああいあうえあ")  
+"romaji" will do the opposite. (i.e. "_ああいあうえあ" -> "_a-a-i-a-u-e-a")
+
+The script can convert more than one path at once.
+
+# Example
+
+```cl
+python main.py "C:\OpenUTAU\Singers\test_bank" hiragana
+
+Scanning "C:\OpenUTAU\Singers\test_bank"
+Converting...
+Converted test_bank. Hiragana files are in "test_bank_hiragana".
+```
+
+```cl
+python main.py "C:\OpenUTAU\Singers\bankone" "C:\OpenUTAU\Singers\banktwo" romaji
+
+Scanning "C:\OpenUTAU\Singers\bankone"
+Converting...
+Converted bankone. Romaji files are in "bankone_romaji".
+Scanning "C:\OpenUTAU\Singers\banktwo"
+Converting...
+Converted banktwo. Romaji files are in "banktwo_romaji".
+```

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import main_converter
 import argparse
 
 AUDIO = ["wav", "flac", "aif", "aiff", "aifc", "mp3"]
+FRQ = ["frq", "llsm", "dio", "ctspec"]
 
 
 def main(path, mode):
@@ -20,8 +21,8 @@ def main(path, mode):
         try:
             old = i
             ext = i.split(".")[-1]
-            if ext not in AUDIO:
-                pass  # don't convert if not an audio file
+            if ext not in AUDIO and ext not in FRQ:
+                pass  # don't convert if not an audio file or a frq file
             elif mode == "hiragana":
                 for key in main_converter.hir_dict.keys():
                     i = i.replace(key, main_converter.hir_dict[key])

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ import shutil
 import main_converter
 import argparse
 
+AUDIO = ["wav", "flac", "aif", "aiff", "aifc", "mp3"]
+
 
 def main(path, mode):
     bankname = path.split("\\")[-1]  # Get the name of the voicebank folder to use as the name of the new folder
@@ -15,51 +17,51 @@ def main(path, mode):
     except FileExistsError:
         pass  # If it does exist, this is okay
     for i in paths:
-        old = i
-        if mode == "hiragana":
-            for key in main_converter.hir_dict.keys():
-                i = i.replace(key, main_converter.hir_dict[key])
-            i = i.replace("_", "")
-            i = i.replace(".わv", ".wav")
-            i = i.replace("わv.frq", "_wav.frq")
-            i = i.replace("わv.llsm", "wav.llsm")
-            i = i.replace(".あいf", ".aif")
-            i = i.replace("あいf.frq", "_aif.frq")
-            i = i.replace("あいf.llsm", "aif.llsm")
-            i = i.replace(".あいff", ".aiff")
-            i = i.replace("あいff.frq", "_aiff.frq")
-            i = i.replace("あいff.llsm", "aiff.llsm")
-            i = i.replace(".あいfc", ".aifc")
-            i = i.replace("あいfc.frq", "_aifc.frq")
-            i = i.replace("あいfc.llsm", "aifc.llsm")
-            i = "_" + i
-            i = i.replace("_でsc.mrq", "desc.mrq")
-            i = i.replace("_おと.いに", "oto.ini")
-            try:
-                shutil.copy(path + "\\" + old, f".\\{bankname}_{mode}\\" + i)
-            except FileNotFoundError:
-                print(f"File not found? Skipping {old}")
-            except PermissionError:
-                print(f"Permission error. Skipping {old}")
-            except:
-                print(f"Unknown error. Skipping {old}")
-        elif mode == "romaji":
-            for key in main_converter.rom_dict.keys():
-                i = i.replace(key, "-" + main_converter.rom_dict[key])
-            if i.startswith("_-"):
-                i = i.replace("_-", "_")
-            if i.startswith("-"):
-                i = i[1:]
-            try:
-                shutil.copy(path + "\\" + old, f".\\{bankname}_{mode}\\" + i)
-            except FileNotFoundError:
-                print(f"File not found? Skipping {old}")
-            except PermissionError:
-                print(f"Permission error. Skipping {old}")
-            except:
-                print(f"Unknown error. Skipping {old}")
-        else:
-            print("No valid conversion mode specified!")
+        try:
+            old = i
+            ext = i.split(".")[-1]
+            if ext not in AUDIO:
+                pass  # don't convert if not an audio file
+            elif mode == "hiragana":
+                for key in main_converter.hir_dict.keys():
+                    i = i.replace(key, main_converter.hir_dict[key])
+                i = i.replace("_", "")
+                i = i.replace(".わv", ".wav")
+                i = i.replace("flあc", "flac")
+                i = i.replace("わv.frq", "_wav.frq")
+                i = i.replace("わv.llsm", "wav.llsm")
+                i = i.replace(".あいf", ".aif")
+                i = i.replace("あいf.frq", "_aif.frq")
+                i = i.replace("あいf.llsm", "aif.llsm")
+                i = i.replace(".あいff", ".aiff")
+                i = i.replace("あいff.frq", "_aiff.frq")
+                i = i.replace("あいff.llsm", "aiff.llsm")
+                i = i.replace(".あいfc", ".aifc")
+                i = i.replace("あいfc.frq", "_aifc.frq")
+                i = i.replace("あいfc.llsm", "aifc.llsm")
+                i = "_" + i
+                i = i.replace("_でsc.mrq", "desc.mrq")
+                i = i.replace("_おと.いに", "oto.ini")
+            elif mode == "romaji":
+                for key in main_converter.rom_dict.keys():
+                    i = i.replace(key, "-" + main_converter.rom_dict[key])
+
+                if i.startswith("_-"):
+                    i = i.replace("_-", "_")
+
+                if i.startswith("-"):
+                    i = i[1:]
+            else:
+                print("No valid conversion mode specified!")
+
+            # finally, copy the file to the new folder
+            shutil.copy(path + "\\" + old, f".\\{bankname}_{mode}\\" + i)
+        except FileNotFoundError:
+            print(f"File not found? Skipping {old}")
+        except PermissionError:
+            print(f"Permission error. Skipping {old}")
+        except:
+            print(f"Unknown error. Skipping {old}")
     print(f"Converted {bankname}. {mode.title()} files are in \"{bankname}_{mode}\".")
 
 


### PR DESCRIPTION
Change converter to only aconvert wav, aiff, flac, and mp3 files. Copies all other files unchanged.

Slight refactor of converter and except blocks.

Update README for new argparse usage.